### PR TITLE
Ensure session flags are set once session is initialised to prevent NPE

### DIFF
--- a/src/main/java/com/hierynomus/smbj/connection/SMBSessionBuilder.java
+++ b/src/main/java/com/hierynomus/smbj/connection/SMBSessionBuilder.java
@@ -176,6 +176,7 @@ public class SMBSessionBuilder {
                     context.setApplicationKey(deriveKey(context.getSessionKey(), KDF_APP_LABEL, KDF_APP_CONTEXT, alg));
                 }
             }
+            context.established(response);
             return session;
         }
     }

--- a/src/test/groovy/com/hierynomus/smbj/connection/ConnectionSpec.groovy
+++ b/src/test/groovy/com/hierynomus/smbj/connection/ConnectionSpec.groovy
@@ -113,6 +113,18 @@ class ConnectionSpec extends Specification {
     exc.statusCode == NtStatus.STATUS_NETWORK_SESSION_EXPIRED.value
   }
 
+  def "should initialise session flags in context once authenticated"() {
+    given:
+    def connect = client.connect("localhost")
+    def session = connect.authenticate(new AuthenticationContext("foo", "bar".toCharArray(), null))
+
+    when:
+    def guest = session.isGuest()
+
+    then:
+    !guest
+  }
+
   class EventPersister {
     def events = [] as List<SMBEvent>
 


### PR DESCRIPTION
Established on session context is never called, meaning the session flags are never initialised on the session context which can lead to NPE when calling isGuest() or isAnonymous() on a session instance.

Based on code prior to 10.0.1-SNAPSHOT, I've added this right at the end of the session initialisation but happy to move elsewhere if deemed appropriate.